### PR TITLE
Update AutoMiner for Alpha 19 b163 compatibility.

### DIFF
--- a/Snufkin_Autominer/Config/items.xml
+++ b/Snufkin_Autominer/Config/items.xml
@@ -1,5 +1,5 @@
 <configs>
-	<append xpath="/items/item[@name='meleeToolAuger']">
+	<append xpath="/items/item[@name='meleeToolPickT3Auger']">
 		<effect_group tiered="false">
 			<passive_effect name="CraftingTime" operation="base_add" value="0,-120,-240,-360,-480,-600" tier="1,2,3,4,5,6" tags="autominer"/>
 			<passive_effect name="CraftingTime" operation="base_add" value="-20" tags="autominer"/>

--- a/Snufkin_Autominer/Config/recipes.xml
+++ b/Snufkin_Autominer/Config/recipes.xml
@@ -1,27 +1,27 @@
 <configs>
 	<append xpath="/recipes">
-		<recipe name="resourceOilShale" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceOilShale" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceClayLump" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceClayLump" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceScrapBrass" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceScrapBrass" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceCoal" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceCoal" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceScrapIron" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceScrapIron" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceScrapLead" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceScrapLead" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourceRockSmall" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourceRockSmall" count="1000" craft_area="AutoMiner" craft_time="3660" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
-		<recipe name="resourcePotassiumNitratePowder" count="1000" craft_time="3660" craft_area="AutoMiner" tags="autominer" craft_tool="meleeToolAuger">
+		<recipe name="resourcePotassiumNitratePowder" count="1000" craft_time="3660" craft_area="AutoMiner" tags="autominer" craft_tool="meleeToolPickT3Auger">
 			<ingredient name="ammoGasCan" count="1000"/>
 		</recipe>
 		<recipe name="AutoMiner" count="1" craft_time="300" craft_area="workbench" tags="perkAdvancedEngineering,learnable" >


### PR DESCRIPTION
This PR replaces all instances of meleeToolAuger with meleeToolPickT3Auger to enable the AutoMiner to work on Alpha 19 b163. I've tested this on my own private dedicated server, and while I have yet to build the miner legitimately, a cheated in miner seems to be working as intended, and I have a mining operation started.